### PR TITLE
include basic smoke tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,5 +15,6 @@ jobs:
       - run: go install ./...
       - run: protolock
       - run: protolock init
+      - run: cat proto.lock | grep "testdata/test.proto"
       - run: protolock status
       - run: protolock commit


### PR DESCRIPTION
- add basic integration / smoke test
- test `proto.lock` file contents