### PR TITLE
add release script for cross-compiling binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 proto.lock
 protolock
+builds

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set +x
+mkdir -p builds
+
+rm builds/*
+
+NOW=`date +%F.%s`
+BUILD_SRC=cmd/protolock/main.go
+NAME=protolock
+BUILD_CMD="go build -o $NAME $BUILD_SRC"
+
+LINUX_TAR="protolock-$NOW-linux.tgz"
+WIN_TAR="protolock-$NOW-windows.tgz"
+MAC_TAR="protolock-$NOW-macos.tgz"
+
+# cross compile for linux, windows, macOS
+GOOS=linux $BUILD_CMD
+tar czf $LINUX_TAR protolock README.md LICENSE
+mv $LINUX_TAR builds
+
+GOOS=windows $BUILD_CMD 
+mv protolock protolock.exe
+tar czf $WIN_TAR  protolock.exe README.md LICENSE
+mv $WIN_TAR builds
+
+GOOS=darwin $BUILD_CMD
+tar czf $MAC_TAR protolock README.md LICENSE
+mv $MAC_TAR builds

--- a/release.sh
+++ b/release.sh
@@ -17,13 +17,16 @@ MAC_TAR="protolock-$NOW-macos.tgz"
 # cross compile for linux, windows, macOS
 GOOS=linux $BUILD_CMD
 tar czf $LINUX_TAR protolock README.md LICENSE
+rm protolock
 mv $LINUX_TAR builds
 
 GOOS=windows $BUILD_CMD 
 mv protolock protolock.exe
 tar czf $WIN_TAR  protolock.exe README.md LICENSE
+rm protolock.exe
 mv $WIN_TAR builds
 
 GOOS=darwin $BUILD_CMD
 tar czf $MAC_TAR protolock README.md LICENSE
+rm protolock
 mv $MAC_TAR builds


### PR DESCRIPTION
create pre-built binaries for windows, macos, linux and include readme + license in archive.