### PR TITLE
make lock file OS-agnostic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,6 @@ jobs:
       - run: go install ./...
       - run: protolock
       - run: protolock init
-      - run: cat proto.lock | grep "testdata/test.proto"
+      - run: cat proto.lock | grep "testdata:/:test.proto"
       - run: protolock status
       - run: protolock commit

--- a/parse.go
+++ b/parse.go
@@ -20,8 +20,8 @@ type Protolock struct {
 }
 
 type Definition struct {
-	Filepath string `json:"filepath,omitempty"`
-	Def      Entry  `json:"def,omitempty"`
+	Filepath protopath `json:"protopath,omitempty"`
+	Def      Entry     `json:"def,omitempty"`
 }
 
 type Entry struct {
@@ -30,11 +30,11 @@ type Entry struct {
 }
 
 type Message struct {
-	Name          string   `json:"name,omitempty"`
-	Fields        []Field  `json:"fields,omitempty"`
-	ReservedIDs   []int    `json:"reserved_ids,omitempty"`
-	ReservedNames []string `json:"reserved_names,omitempty"`
-	Filepath      string   `json:"filepath,omitempty"`
+	Name          string    `json:"name,omitempty"`
+	Fields        []Field   `json:"fields,omitempty"`
+	ReservedIDs   []int     `json:"reserved_ids,omitempty"`
+	ReservedNames []string  `json:"reserved_names,omitempty"`
+	Filepath      protopath `json:"filepath,omitempty"`
 }
 
 type Field struct {
@@ -45,9 +45,9 @@ type Field struct {
 }
 
 type Service struct {
-	Name     string `json:"name,omitempty"`
-	RPCs     []RPC  `json:"rpcs,omitempty"`
-	Filepath string `json:"filepath,omitempty"`
+	Name     string    `json:"name,omitempty"`
+	RPCs     []RPC     `json:"rpcs,omitempty"`
+	Filepath protopath `json:"filepath,omitempty"`
 }
 
 type RPC struct {
@@ -63,7 +63,7 @@ type Report struct {
 }
 
 type Warning struct {
-	Filepath string
+	Filepath protopath
 	Message  string
 }
 
@@ -208,7 +208,7 @@ func compare(current, update Protolock) (Report, error) {
 func getUpdatedLock() (*Protolock, error) {
 	// files is a map of filepaths to string buffers to be joined into the
 	// proto.lock file.
-	files := make(map[string]Entry)
+	files := make(map[protopath]Entry)
 
 	root, err := os.Getwd()
 	if err != nil {
@@ -242,7 +242,7 @@ func getUpdatedLock() (*Protolock, error) {
 
 		localPath := strings.TrimPrefix(path, root)
 		localPath = strings.TrimPrefix(localPath, string(filepath.Separator))
-		files[localPath] = entry
+		files[protoPath(protopath(localPath))] = entry
 		return nil
 	})
 	if err != nil {
@@ -255,7 +255,7 @@ func getUpdatedLock() (*Protolock, error) {
 	var updated Protolock
 	for fp, def := range files {
 		updated.Definitions = append(updated.Definitions, Definition{
-			Filepath: fp,
+			Filepath: protopath(fp),
 			Def:      def,
 		})
 	}

--- a/protopath.go
+++ b/protopath.go
@@ -1,0 +1,31 @@
+package protolock
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const (
+	filesep  = string(filepath.Separator)
+	protosep = ":/:"
+)
+
+type protopath string
+
+// convert a path in the protopath format to the OS path format
+func osPath(protoPath protopath) protopath {
+	return protopath(
+		strings.Replace(string(protoPath), protosep, filesep, -1),
+	)
+}
+
+// convert a path in the OS path format to protopath format
+func protoPath(osPath protopath) protopath {
+	return protopath(
+		strings.Replace(string(osPath), filesep, protosep, -1),
+	)
+}
+
+func (p protopath) String() string {
+	return string(p)
+}

--- a/protopath_test.go
+++ b/protopath_test.go
@@ -1,0 +1,21 @@
+package protolock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOSPathToProtoPath(t *testing.T) {
+	path := protopath("testdata/test.proto")
+	p := protoPath(path)
+	assert.Equal(t, "testdata:test.proto", string(p))
+	assert.Equal(t, protopath("testdata:test.proto"), p)
+}
+
+func TestProtoPathToOSPath(t *testing.T) {
+	path := protopath("testdata:test.proto")
+	p := osPath(path)
+	assert.Equal(t, protopath("testdata/test.proto"), p)
+	assert.Equal(t, "testdata/test.proto", string(p))
+}

--- a/protopath_test.go
+++ b/protopath_test.go
@@ -9,12 +9,12 @@ import (
 func TestOSPathToProtoPath(t *testing.T) {
 	path := protopath("testdata/test.proto")
 	p := protoPath(path)
-	assert.Equal(t, "testdata:test.proto", string(p))
-	assert.Equal(t, protopath("testdata:test.proto"), p)
+	assert.Equal(t, "testdata:/:test.proto", string(p))
+	assert.Equal(t, protopath("testdata:/:test.proto"), p)
 }
 
 func TestProtoPathToOSPath(t *testing.T) {
-	path := protopath("testdata:test.proto")
+	path := protopath("testdata:/:test.proto")
 	p := osPath(path)
 	assert.Equal(t, protopath("testdata/test.proto"), p)
 	assert.Equal(t, "testdata/test.proto", string(p))

--- a/rules.go
+++ b/rules.go
@@ -49,7 +49,7 @@ type RuleFunc func(current, updated Protolock) ([]Warning, bool)
 				       [2] -> 1
 				       [3] -> 1
 */
-type lockIDsMap map[string]map[string]map[int]int
+type lockIDsMap map[protopath]map[string]map[int]int
 
 // lockNamesMap:
 // table of filepath -> message name -> field name -> times name encountered (or the field ID)
@@ -68,19 +68,19 @@ type lockIDsMap map[string]map[string]map[int]int
 						-> 	["field_two"] 	-> 	2
 						-> 	["field_three"] -> 	3
 */
-type lockNamesMap map[string]map[string]map[string]int
+type lockNamesMap map[protopath]map[string]map[string]int
 
 // lockFieldMap:
 // table of filepath -> message name -> field name -> field type
-type lockFieldMap map[string]map[string]map[string]Field
+type lockFieldMap map[protopath]map[string]map[string]Field
 
 // lockRPCMap:
 // table of filepath -> service name -> rpc name -> rpc type
-type lockRPCMap map[string]map[string]map[string]RPC
+type lockRPCMap map[protopath]map[string]map[string]RPC
 
 // lockFieldIDNameMap:
 // table of filepath -> message name -> field ID -> field name
-type lockFieldIDNameMap map[string]map[string]map[int]string
+type lockFieldIDNameMap map[protopath]map[string]map[int]string
 
 // NoUsingReservedFields compares the current vs. updated Protolock definitions
 // and will return a list of warnings if any message's previously reserved fields
@@ -251,7 +251,7 @@ func NoChangingFieldIDs(cur, upd Protolock) ([]Warning, bool) {
 							msgName, fieldName, updFieldID, fieldID,
 						)
 						warnings = append(warnings, Warning{
-							Filepath: path,
+							Filepath: osPath(path),
 							Message:  msg,
 						})
 					}
@@ -294,7 +294,7 @@ func NoChangingFieldTypes(cur, upd Protolock) ([]Warning, bool) {
 							msgName, fieldName, updField.Type, field.Type,
 						)
 						warnings = append(warnings, Warning{
-							Filepath: path,
+							Filepath: osPath(path),
 							Message:  msg,
 						})
 					}
@@ -305,7 +305,7 @@ func NoChangingFieldTypes(cur, upd Protolock) ([]Warning, bool) {
 							msgName, fieldName, updField.IsRepeated, field.IsRepeated,
 						)
 						warnings = append(warnings, Warning{
-							Filepath: path,
+							Filepath: osPath(path),
 							Message:  msg,
 						})
 					}
@@ -354,7 +354,7 @@ func NoChangingFieldNames(cur, upd Protolock) ([]Warning, bool) {
 							msgName, updFieldName, fieldID, fieldName,
 						)
 						warnings = append(warnings, Warning{
-							Filepath: path,
+							Filepath: osPath(path),
 							Message:  msg,
 						})
 					}
@@ -454,7 +454,7 @@ func NoRemovingFieldsWithoutReserve(cur, upd Protolock) ([]Warning, bool) {
 							msgName, field.Name,
 						)
 						warnings = append(warnings, Warning{
-							Filepath: path,
+							Filepath: osPath(path),
 							Message:  msg,
 						})
 					}
@@ -471,7 +471,7 @@ func NoRemovingFieldsWithoutReserve(cur, upd Protolock) ([]Warning, bool) {
 							msgName, field.ID,
 						)
 						warnings = append(warnings, Warning{
-							Filepath: path,
+							Filepath: osPath(path),
 							Message:  msg,
 						})
 					}

--- a/rules_test.go
+++ b/rules_test.go
@@ -473,7 +473,7 @@ func parseTestProto(t *testing.T, proto string) Protolock {
 	return Protolock{
 		Definitions: []Definition{
 			{
-				Filepath: "io.Reader (test)",
+				Filepath: protopath("testdata/no-test.proto"),
 				Def:      entry,
 			},
 		},


### PR DESCRIPTION
Fix for #10

- use a substitute filepath separator `:/:` when writing out the lock file, and convert it to the native OS's file path when reading 