### PR TITLE
add support and tests for comment hints

### DIFF
--- a/hints_test.go
+++ b/hints_test.go
@@ -30,6 +30,16 @@ service ChannelChanger {
   rpc Next(stream NextRequest) returns (Channel);
   rpc Previous(PreviousRequest) returns (stream Channel);
 }
+
+// @protolock:skip
+message Volume {
+	float32 level = 1;
+}
+
+service VolumeChanger {
+	rpc Increase(stream IncreaseRequest) returns (Volume);
+	rpc Decrease(DecreaseRequest) returns (Volume);
+  }
 `
 
 func TestHints(t *testing.T) {
@@ -39,9 +49,11 @@ func TestHints(t *testing.T) {
 	for _, def := range lock.Definitions {
 		t.Run("skip:messages", func(t *testing.T) {
 			assert.Len(t, def.Def.Messages, 1)
+			assert.Equal(t, def.Def.Messages[0].Name, "NextRequest")
 		})
 		t.Run("skip:services", func(t *testing.T) {
-			assert.Len(t, def.Def.Services, 0)
+			assert.Len(t, def.Def.Services, 1)
+			assert.Equal(t, def.Def.Services[0].Name, "VolumeChanger")
 		})
 	}
 }


### PR DESCRIPTION
Partially closes #13 (support for annotating messages and services)

Starting with `@protolock:skip`, known annotations may know indicate certain behavior hints for messages and services. `@protolock` is a namespace, followed by a separator `:` and a directive (`skip`).

```protobuf
// @protolock:skip
message DontLockMe {
  string name = 1;
  int32 age = 2;
}
``` 

The tests in `hints_test.go` show the variety of ways a comment is associated to a message or service by its placement.