### PR TITLE
fix conflict when using nested messages 

### DIFF
--- a/rules.go
+++ b/rules.go
@@ -584,22 +584,22 @@ func NoChangingRPCSignature(cur, upd Protolock) ([]Warning, bool) {
 }
 
 func getReservedFieldsRecursive(reservedIDMap lockIDsMap, reservedNameMap lockNamesMap, filepath protopath, prefix string, msg Message) {
-	name := prefix + msg.Name
+	msgName := prefix + msg.Name
 	for _, id := range msg.ReservedIDs {
-		if reservedIDMap[filepath][name] == nil {
-			reservedIDMap[filepath][name] = make(map[int]int)
+		if reservedIDMap[filepath][msgName] == nil {
+			reservedIDMap[filepath][msgName] = make(map[int]int)
 		}
-		reservedIDMap[filepath][name][id]++
+		reservedIDMap[filepath][msgName][id]++
 	}
 	for _, name := range msg.ReservedNames {
-		if reservedNameMap[filepath][name] == nil {
-			reservedNameMap[filepath][name] = make(map[string]int)
+		if reservedNameMap[filepath][msgName] == nil {
+			reservedNameMap[filepath][msgName] = make(map[string]int)
 		}
-		reservedNameMap[filepath][name][name]++
+		reservedNameMap[filepath][msgName][name]++
 	}
 
 	for _, msg := range msg.Messages {
-		getReservedFieldsRecursive(reservedIDMap, reservedNameMap, filepath, name+"_", msg)
+		getReservedFieldsRecursive(reservedIDMap, reservedNameMap, filepath, msgName+"_", msg)
 	}
 }
 

--- a/rules.go
+++ b/rules.go
@@ -1,6 +1,8 @@
 package protolock
 
-import "fmt"
+import (
+	"fmt"
+)
 
 var (
 	// ruleFuncs provides a complete list of all funcs to be run to compare
@@ -82,6 +84,24 @@ type lockRPCMap map[protopath]map[string]map[string]RPC
 // table of filepath -> message name -> field ID -> field name
 type lockFieldIDNameMap map[protopath]map[string]map[int]string
 
+func parseNestedMessages(reservedIDMap lockIDsMap, reservedNameMap lockNamesMap, filepath protopath, prefix string, msg Message) {
+	name := prefix + msg.Name
+	for _, field := range msg.Fields {
+		if reservedIDMap[filepath][name] == nil {
+			reservedIDMap[filepath][name] = make(map[int]int)
+		}
+		if reservedNameMap[filepath][name] == nil {
+			reservedNameMap[filepath][name] = make(map[string]int)
+		}
+		reservedIDMap[filepath][name][field.ID]++
+		reservedNameMap[filepath][name][field.Name]++
+	}
+
+	for _, m := range msg.Messages {
+		parseNestedMessages(reservedIDMap, reservedNameMap, filepath, name+"_", m)
+	}
+}
+
 // NoUsingReservedFields compares the current vs. updated Protolock definitions
 // and will return a list of warnings if any message's previously reserved fields
 // or IDs are now being used as part of the same message.
@@ -102,16 +122,7 @@ func NoUsingReservedFields(cur, upd Protolock) ([]Warning, bool) {
 			reservedNameMap[def.Filepath] = make(map[string]map[string]int)
 		}
 		for _, msg := range def.Def.Messages {
-			for _, field := range msg.Fields {
-				if reservedIDMap[def.Filepath][msg.Name] == nil {
-					reservedIDMap[def.Filepath][msg.Name] = make(map[int]int)
-				}
-				if reservedNameMap[def.Filepath][msg.Name] == nil {
-					reservedNameMap[def.Filepath][msg.Name] = make(map[string]int)
-				}
-				reservedIDMap[def.Filepath][msg.Name][field.ID]++
-				reservedNameMap[def.Filepath][msg.Name][field.Name]++
-			}
+			parseNestedMessages(reservedIDMap, reservedNameMap, def.Filepath, "", msg)
 		}
 	}
 
@@ -572,6 +583,26 @@ func NoChangingRPCSignature(cur, upd Protolock) ([]Warning, bool) {
 	return nil, true
 }
 
+func getReservedFieldsRecursive(reservedIDMap lockIDsMap, reservedNameMap lockNamesMap, filepath protopath, prefix string, msg Message) {
+	name := prefix + msg.Name
+	for _, id := range msg.ReservedIDs {
+		if reservedIDMap[filepath][name] == nil {
+			reservedIDMap[filepath][name] = make(map[int]int)
+		}
+		reservedIDMap[filepath][name][id]++
+	}
+	for _, name := range msg.ReservedNames {
+		if reservedNameMap[filepath][name] == nil {
+			reservedNameMap[filepath][name] = make(map[string]int)
+		}
+		reservedNameMap[filepath][name][name]++
+	}
+
+	for _, msg := range msg.Messages {
+		getReservedFieldsRecursive(reservedIDMap, reservedNameMap, filepath, name+"_", msg)
+	}
+}
+
 // getReservedFields gets all the reserved field numbers and names, and stashes
 // them in a lockIDsMap and lockNamesMap to be checked against.
 func getReservedFields(lock Protolock) (lockIDsMap, lockNamesMap) {
@@ -585,19 +616,9 @@ func getReservedFields(lock Protolock) (lockIDsMap, lockNamesMap) {
 		if reservedNameMap[def.Filepath] == nil {
 			reservedNameMap[def.Filepath] = make(map[string]map[string]int)
 		}
+
 		for _, msg := range def.Def.Messages {
-			for _, id := range msg.ReservedIDs {
-				if reservedIDMap[def.Filepath][msg.Name] == nil {
-					reservedIDMap[def.Filepath][msg.Name] = make(map[int]int)
-				}
-				reservedIDMap[def.Filepath][msg.Name][id]++
-			}
-			for _, name := range msg.ReservedNames {
-				if reservedNameMap[def.Filepath][msg.Name] == nil {
-					reservedNameMap[def.Filepath][msg.Name] = make(map[string]int)
-				}
-				reservedNameMap[def.Filepath][msg.Name][name]++
-			}
+			getReservedFieldsRecursive(reservedIDMap, reservedNameMap, def.Filepath, "", msg)
 		}
 	}
 

--- a/rules.go
+++ b/rules.go
@@ -23,6 +23,8 @@ var (
 	debug  = false
 )
 
+const nestedPrefix = "."
+
 // SetStrict enables the user to toggle strict mode on and off.
 func SetStrict(mode bool) {
 	strict = mode
@@ -98,7 +100,7 @@ func parseNestedMessages(reservedIDMap lockIDsMap, reservedNameMap lockNamesMap,
 	}
 
 	for _, m := range msg.Messages {
-		parseNestedMessages(reservedIDMap, reservedNameMap, filepath, name+"_", m)
+		parseNestedMessages(reservedIDMap, reservedNameMap, filepath, name+nestedPrefix, m)
 	}
 }
 
@@ -599,7 +601,8 @@ func getReservedFieldsRecursive(reservedIDMap lockIDsMap, reservedNameMap lockNa
 	}
 
 	for _, msg := range msg.Messages {
-		getReservedFieldsRecursive(reservedIDMap, reservedNameMap, filepath, msgName+"_", msg)
+		// recursively call func, using parent message name and a '.' as prefix
+		getReservedFieldsRecursive(reservedIDMap, reservedNameMap, filepath, msgName+nestedPrefix, msg)
 	}
 }
 

--- a/testdata/test.proto
+++ b/testdata/test.proto
@@ -16,6 +16,18 @@ message Channel {
   A msg = 44;
 }
 
+message Display {
+  int32 width = 1;
+  int32 height = 2;
+
+  message A {
+    reserved 2;
+    int64 id = 1;
+  }
+
+  A msg = 44;
+}
+
 // @protolock:skip
 message NextRequest {}
 message PreviousRequest {}


### PR DESCRIPTION
+ support for same message name while still checking for not reusing reserved fields #17

@celrenheit, it appears this breaks `TestUsingReservedFields`. The 3 expected warnings should include the 2 for the re-use of reused field names `foo` and `bar`. 

```shell
=== RUN   TestUsingReservedFields
RUN RULE: NoUsingReservedFields
# Warnings: 1
1). "Channel" is re-using ID: 4, a reserved field number [testdata/no-test.proto]
END RULE: NoUsingReservedFields
===
RUN RULE: NoUsingReservedFields
# Warnings: 0
END RULE: NoUsingReservedFields
===
--- FAIL: TestUsingReservedFields (0.00s)
	/Users/smanuel/go/src/github.com/nilslice/protolock/assertions.go:247: 
                          
	Error Trace:	rules_test.go:457
		
	Error:      	"[{testdata/no-test.proto "Channel" is re-using ID: 4, a reserved field number}]" should have 3 item(s), but has 1
		
	Test:       	TestUsingReservedFields
FAIL
FAIL	github.com/nilslice/protolock	0.064s
Error: Tests failed.
```