### PR TITLE
oneof does not need validation outside of regular field validation

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -33,16 +33,10 @@ type Message struct {
 	Name          string    `json:"name,omitempty"`
 	Fields        []Field   `json:"fields,omitempty"`
 	Maps          []Map     `json:"maps,omitempty"`
-	OneOfs        []OneOf   `json:"one_ofs,omitempty"`
 	ReservedIDs   []int     `json:"reserved_ids,omitempty"`
 	ReservedNames []string  `json:"reserved_names,omitempty"`
 	Filepath      protopath `json:"filepath,omitempty"`
 	Messages      []Message `json:"messages,omitempty"`
-}
-
-type OneOf struct {
-	Name   string  `json:"name,omitempty"`
-	Fields []Field `json:"fields,omitempty"`
 }
 
 type Map struct {
@@ -196,10 +190,7 @@ func parseMessage(m *proto.Message) Message {
 					})
 				}
 			}
-			msg.OneOfs = append(msg.OneOfs, OneOf{
-				Name:   oo.Name,
-				Fields: fields,
-			})
+			msg.Fields = append(msg.Fields, fields...)
 		}
 
 		if r, ok := v.(*proto.Reserved); ok {

--- a/rules.go
+++ b/rules.go
@@ -417,27 +417,6 @@ func NoChangingFieldNames(cur, upd Protolock) ([]Warning, bool) {
 			}
 		}
 	}
-	// for path, msgMap := range curOneOfsMap {
-	// 	for msgName, ooMap := range msgMap {
-	// 		for ooName, fieldMap := range ooMap {
-	// 			for fieldID, fieldName := range fieldMap {
-	// 				updOOFieldName, ok := updOneOfsMap[path][msgName][ooName][fieldID]
-	// 				if ok {
-	// 					if updOOFieldName != fieldName {
-	// 						msg := fmt.Sprintf(
-	// 							`"%s" oneof field: "%s" ID: %d has an updated name, previously "%s"`,
-	// 							msgName, updOOFieldName, fieldID, fieldName,
-	// 						)
-	// 						warnings = append(warnings, Warning{
-	// 							Filepath: osPath(path),
-	// 							Message:  msg,
-	// 						})
-	// 					}
-	// 				}
-	// 			}
-	// 		}
-	// 	}
-	// }
 
 	if debug {
 		concludeRuleDebug("NoChangingFieldNames", warnings)


### PR DESCRIPTION
Since all fields inside a `oneOf` are subject to the same validation procedures as fields and there are no API compatibility issues introduced by adding/removing fields from a `oneOf` or changing the name of a `oneOf` and we can just check the member fields as if they were normal fields.

There are however some issues related to assumptions you can make about the presence of data between mismatched versions when the structure of a `oneOf` changes. See https://developers.google.com/protocol-buffers/docs/proto#backwards-compatibility-issues for more.

