### PR TITLE
add --ignore flag to support skipping paths at cli level

### DIFF
--- a/cmd/protolock/main.go
+++ b/cmd/protolock/main.go
@@ -32,7 +32,7 @@ var (
 	options = flag.NewFlagSet("options", flag.ExitOnError)
 	debug   = options.Bool("debug", false, "toggle debug mode for verbose output")
 	strict  = options.Bool("strict", true, "toggle strict mode, to determine which rules are enforced")
-	ignore = options.String("ignore", "", "Comma-separated list of directories to ignore.")
+	ignore  = options.String("ignore", "", "comma-separated list of directories to ignore.")
 )
 
 func main() {

--- a/cmd/protolock/main.go
+++ b/cmd/protolock/main.go
@@ -32,6 +32,7 @@ var (
 	options = flag.NewFlagSet("options", flag.ExitOnError)
 	debug   = options.Bool("debug", false, "toggle debug mode for verbose output")
 	strict  = options.Bool("strict", true, "toggle strict mode, to determine which rules are enforced")
+	ignore = options.String("ignore", "", "Comma-separated list of directories to ignore.")
 )
 
 func main() {
@@ -49,8 +50,9 @@ func main() {
 	switch os.Args[1] {
 	case "-h", "--help", "help":
 		fmt.Println(usage)
+
 	case "init":
-		r, err := protolock.Init()
+		r, err := protolock.Init(*ignore)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -63,7 +65,7 @@ func main() {
 		}
 
 	case "commit":
-		r, err := protolock.Commit()
+		r, err := protolock.Commit(*ignore)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
@@ -76,7 +78,7 @@ func main() {
 		}
 
 	case "status":
-		report, err := protolock.Status()
+		report, err := protolock.Status(*ignore)
 		if err != nil {
 			if len(report.Warnings) > 0 {
 				for _, w := range report.Warnings {

--- a/commit.go
+++ b/commit.go
@@ -8,12 +8,13 @@ import (
 
 // Commit will return an io.Reader with the lock representation data for caller to
 // use as needed.
-func Commit() (io.Reader, error) {
+func Commit(ignore string) (io.Reader, error) {
 	if _, err := os.Stat(LockFileName); err != nil && os.IsNotExist(err) {
 		fmt.Println(`no "proto.lock" file found, first run "init"`)
 		os.Exit(1)
 	}
-	updated, err := getUpdatedLock()
+
+	updated, err := getUpdatedLock(ignore)
 	if err != nil {
 		return nil, err
 	}

--- a/init.go
+++ b/init.go
@@ -12,12 +12,13 @@ const protoSuffix = ".proto"
 
 // Init will return an io.Reader with the lock representation data for caller to
 // use as needed.
-func Init() (io.Reader, error) {
+func Init(ignore string) (io.Reader, error) {
 	if _, err := os.Stat(LockFileName); err == nil && !os.IsNotExist(err) {
 		fmt.Println(`a "proto.lock" file was already found, use "commit" to update`)
 		os.Exit(1)
 	}
-	updated, err := getUpdatedLock()
+
+	updated, err := getUpdatedLock(ignore)
 	if err != nil {
 		return nil, err
 	}

--- a/parse.go
+++ b/parse.go
@@ -291,14 +291,15 @@ func getProtoFiles(root string, ignores string) ([]string, error) {
 			return nil
 		}
 
-		// if ignore, skip
+		// skip if path is within an ignored path
 		if ignores != "" {
 			for _, ignore := range strings.Split(ignores, ",") {
-				rootIgnore := root + "/" + ignore
+				rootIgnore := filepath.Join(root, ignore)
 				stat, err := os.Stat(rootIgnore)
 				if err == nil {
-					if stat.IsDir() && !strings.HasSuffix(rootIgnore, "/") {
-						rootIgnore += "/"
+					const sep = string(filepath.Separator)
+					if stat.IsDir() && !strings.HasSuffix(rootIgnore, sep) {
+						rootIgnore += sep
 					}
 
 					if strings.HasPrefix(path, rootIgnore) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,48 +1,71 @@
 package protolock
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+var gpfPath = filepath.Join("testdata", "getProtoFiles")
+
 func TestGetProtoFilesFiltersDirectories(t *testing.T) {
-	files, err := getProtoFiles("testdata/getProtoFiles", "")
+	files, err := getProtoFiles(gpfPath, "")
 	assert.NoError(t, err)
 
-	assert.NotContains(t, files, "testdata/getProtoFiles/directory.proto")
-	assert.Contains(t, files, "testdata/getProtoFiles/include/include.proto")
+	path := filepath.Join(gpfPath, "directory.proto")
+	assert.NotContains(t, files, path)
+
+	path = filepath.Join(gpfPath, "include", "include.proto")
+	assert.Contains(t, files, path)
 }
 
 func TestGetProtoFilesFiltersNonProto(t *testing.T) {
-	files, err := getProtoFiles("testdata/getProtoFiles", "")
+	files, err := getProtoFiles(gpfPath, "")
 	assert.NoError(t, err)
 
-	assert.NotContains(t, files, "testdata/getProtoFiles/directory.proto/test.non-proto")
-	assert.Contains(t, files, "testdata/getProtoFiles/include/include.proto")
+	path := filepath.Join(gpfPath, "directory.proto", "test.non-proto")
+	assert.NotContains(t, files, path)
+
+	path = filepath.Join(gpfPath, "include", "include.proto")
+	assert.Contains(t, files, path)
 }
 
 func TestGetProtoFilesIgnoresDirectories(t *testing.T) {
-	files, err := getProtoFiles("testdata/getProtoFiles", "exclude")
+	files, err := getProtoFiles(gpfPath, "exclude")
 	assert.NoError(t, err)
 
-	assert.NotContains(t, files, "testdata/getProtoFiles/exclude/test.proto")
-	assert.Contains(t, files, "testdata/getProtoFiles/include/include.proto")
+	path := filepath.Join(gpfPath, "exclude", "test.proto")
+	assert.NotContains(t, files, path)
+
+	path = filepath.Join(gpfPath, "include", "include.proto")
+	assert.Contains(t, files, path)
 }
 
 func TestGetProtoFilesIgnoresFiles(t *testing.T) {
-	files, err := getProtoFiles("testdata/getProtoFiles", "include/exclude.proto")
+	files, err := getProtoFiles(gpfPath, filepath.Join("include", "exclude.proto"))
 	assert.NoError(t, err)
 
-	assert.NotContains(t, files, "testdata/getProtoFiles/include/exclude.proto")
-	assert.Contains(t, files, "testdata/getProtoFiles/include/include.proto")
+	path := filepath.Join(gpfPath, "include", "exclude.proto")
+	assert.NotContains(t, files, path)
+
+	path = filepath.Join(gpfPath, "include", "include.proto")
+	assert.Contains(t, files, path)
 }
 
 func TestGetProtoFilesIgnoresMultiple(t *testing.T) {
-	files, err := getProtoFiles("testdata/getProtoFiles", "exclude,include/exclude.proto")
+	paths := []string{"exclude", filepath.Join("include", "exclude.proto")}
+	ignores := strings.Join(paths, ",")
+	files, err := getProtoFiles(gpfPath, ignores)
 	assert.NoError(t, err)
 
-	assert.NotContains(t, files, "testdata/getProtoFiles/exclude/test.proto")
-	assert.NotContains(t, files, "testdata/getProtoFiles/include/exclude.proto")
-	assert.Contains(t, files, "testdata/getProtoFiles/include/include.proto")
+	path := filepath.Join(gpfPath, "exclude", "test.proto")
+	assert.NotContains(t, files, path)
+
+	path = filepath.Join(gpfPath, "include", "exclude.proto")
+	assert.NotContains(t, files, path)
+
+	path = filepath.Join(gpfPath, "include", "include.proto")
+	assert.Contains(t, files, path)
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,48 @@
+package protolock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetProtoFilesFiltersDirectories(t *testing.T) {
+	files, err := getProtoFiles("testdata/getProtoFiles", "")
+	assert.NoError(t, err)
+
+	assert.NotContains(t, files, "testdata/getProtoFiles/directory.proto")
+	assert.Contains(t, files, "testdata/getProtoFiles/include/include.proto")
+}
+
+func TestGetProtoFilesFiltersNonProto(t *testing.T) {
+	files, err := getProtoFiles("testdata/getProtoFiles", "")
+	assert.NoError(t, err)
+
+	assert.NotContains(t, files, "testdata/getProtoFiles/directory.proto/test.non-proto")
+	assert.Contains(t, files, "testdata/getProtoFiles/include/include.proto")
+}
+
+func TestGetProtoFilesIgnoresDirectories(t *testing.T) {
+	files, err := getProtoFiles("testdata/getProtoFiles", "exclude")
+	assert.NoError(t, err)
+
+	assert.NotContains(t, files, "testdata/getProtoFiles/exclude/test.proto")
+	assert.Contains(t, files, "testdata/getProtoFiles/include/include.proto")
+}
+
+func TestGetProtoFilesIgnoresFiles(t *testing.T) {
+	files, err := getProtoFiles("testdata/getProtoFiles", "include/exclude.proto")
+	assert.NoError(t, err)
+
+	assert.NotContains(t, files, "testdata/getProtoFiles/include/exclude.proto")
+	assert.Contains(t, files, "testdata/getProtoFiles/include/include.proto")
+}
+
+func TestGetProtoFilesIgnoresMultiple(t *testing.T) {
+	files, err := getProtoFiles("testdata/getProtoFiles", "exclude,include/exclude.proto")
+	assert.NoError(t, err)
+
+	assert.NotContains(t, files, "testdata/getProtoFiles/exclude/test.proto")
+	assert.NotContains(t, files, "testdata/getProtoFiles/include/exclude.proto")
+	assert.Contains(t, files, "testdata/getProtoFiles/include/include.proto")
+}

--- a/protopath_test.go
+++ b/protopath_test.go
@@ -1,13 +1,16 @@
 package protolock
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+var osp = filepath.Join("testdata", "test.proto")
+
 func TestOSPathToProtoPath(t *testing.T) {
-	path := protopath("testdata/test.proto")
+	path := protopath(osp)
 	p := protoPath(path)
 	assert.Equal(t, "testdata:/:test.proto", string(p))
 	assert.Equal(t, protopath("testdata:/:test.proto"), p)
@@ -16,6 +19,6 @@ func TestOSPathToProtoPath(t *testing.T) {
 func TestProtoPathToOSPath(t *testing.T) {
 	path := protopath("testdata:/:test.proto")
 	p := osPath(path)
-	assert.Equal(t, protopath("testdata/test.proto"), p)
-	assert.Equal(t, "testdata/test.proto", string(p))
+	assert.Equal(t, protopath(osp), p)
+	assert.Equal(t, osp, string(p))
 }

--- a/status.go
+++ b/status.go
@@ -7,8 +7,8 @@ import (
 
 // Status will report on any issues encountered when comparing the updated tree
 // of parsed proto files and the current proto.lock file.
-func Status() (Report, error) {
-	updated, err := getUpdatedLock()
+func Status(ignore string) (Report, error) {
+	updated, err := getUpdatedLock(ignore)
 	if err != nil {
 		return Report{}, err
 	}

--- a/testdata/getProtoFiles/exclude.proto
+++ b/testdata/getProtoFiles/exclude.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package exclude;
+
+message Exclude {
+  string name = 1;
+}

--- a/testdata/getProtoFiles/exclude/test.proto
+++ b/testdata/getProtoFiles/exclude/test.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package exclude;
+
+message Test {
+  string name = 1;
+}

--- a/testdata/getProtoFiles/include/exclude.proto
+++ b/testdata/getProtoFiles/include/exclude.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package exclude;
+
+message Exclude {
+  string name = 1;
+}

--- a/testdata/getProtoFiles/include/include.proto
+++ b/testdata/getProtoFiles/include/include.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package include;
+
+message Include {
+  string name = 1;
+}


### PR DESCRIPTION
Thanks to @noel-yap for [contributing](https://github.com/nilslice/protolock/pull/29) this feature! To use, pass the `--ignore` flag to the CLI along with a comma-separated list of paths. 

i.e. `protolock init --ignore=build,lib,vendor`

The example above will ignore any proto included in those paths. For more granular support, use a comment hint: 
```protobuf
// @protolock:skip
message Foo {
  string bar = 1;
  int64 baz = 42;
}
```