### PR TITLE
Deterministic lock

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -403,7 +403,6 @@ func getUpdatedLock(ignores string) (*Protolock, error) {
 	// files is a map of filepaths to string buffers to be joined into the
 	// proto.lock file.
 	var files []ProtoFile
-	// files := make(map[protopath]Entry)
 
 	root, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
@nilslice Using a struct to contain the `protopath` and `def` seems to be enough to produce a deterministic `proto.lock` file.  The diff in the PR is a little strange because the `printIfErr` function is already defined and used in `parse.go`.  Not exactly sure why it's showing up as my change

You can test this out by running:
- `go run cmd/protolock/main.go init` (if no `proto.lock` file is already present)
- Continually run `go run cmd/protolock/main.go commit` to generate a new lock file.  The files and properties remain ordered from the last init/commit
