### PR TITLE
Ordered lock

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       # install binary, test commands
       - run: go install ./...
       - run: protolock
-      - run: protolock init
+      - run: stat proto.lock
       - run: cat proto.lock | grep "testdata:/:test.proto"
       - run: protolock status
       - run: protolock commit

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-proto.lock
 protolock
 pkg

--- a/order_test.go
+++ b/order_test.go
@@ -1,0 +1,37 @@
+package protolock
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const ignoreArg = ""
+
+func TestOrder(t *testing.T) {
+	// verify that the re-production of the same Protolock encoded as json
+	// is equivalent to any previously encoded version of the same Protolock
+	f, err := os.Open("proto.lock")
+	assert.NoError(t, err)
+
+	current, err := protolockFromReader(f)
+	assert.NoError(t, err)
+
+	r, err := Commit(ignoreArg)
+	assert.NoError(t, err)
+	assert.NotNil(t, r)
+
+	updated, err := protolockFromReader(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, current, updated)
+
+	a, err := json.Marshal(current)
+	assert.NoError(t, err)
+	b, err := json.Marshal(updated)
+	assert.NoError(t, err)
+
+	assert.Equal(t, a, b)
+}

--- a/proto.lock
+++ b/proto.lock
@@ -1,0 +1,274 @@
+{
+  "definitions": [
+    {
+      "protopath": "testdata:/:getProtoFiles:/:exclude:/:test.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Test",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "testdata:/:getProtoFiles:/:exclude.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Exclude",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "testdata:/:getProtoFiles:/:include:/:exclude.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Exclude",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "testdata:/:getProtoFiles:/:include:/:include.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "Include",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "testdata:/:test.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "TestEnum",
+            "enum_fields": [
+              {
+                "name": "FIRST",
+                "integer": 0
+              },
+              {
+                "name": "SECOND",
+                "integer": 1
+              },
+              {
+                "name": "SEGUNDO",
+                "integer": 1
+              }
+            ],
+            "reserved_ids": [
+              2
+            ]
+          },
+          {
+            "name": "ContainsEnum.NestedEnum",
+            "enum_fields": [
+              {
+                "name": "ABC",
+                "integer": 1
+              },
+              {
+                "name": "DEF",
+                "integer": 2
+              }
+            ],
+            "reserved_ids": [
+              101
+            ],
+            "reserved_names": [
+              "DEPTH"
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "Channel",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "description",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "foo",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "age",
+                "type": "int32"
+              },
+              {
+                "id": 44,
+                "name": "msg",
+                "type": "A"
+              }
+            ],
+            "reserved_ids": [
+              6,
+              8,
+              9,
+              10,
+              11
+            ],
+            "messages": [
+              {
+                "name": "A",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "id",
+                    "type": "int32"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "Display",
+            "fields": [
+              {
+                "id": 1,
+                "name": "width",
+                "type": "int32"
+              },
+              {
+                "id": 2,
+                "name": "height",
+                "type": "int32"
+              },
+              {
+                "id": 44,
+                "name": "msg",
+                "type": "A"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "b_map",
+                  "type": "int32"
+                }
+              }
+            ],
+            "reserved_ids": [
+              3
+            ],
+            "reserved_names": [
+              "a_map"
+            ],
+            "messages": [
+              {
+                "name": "A",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "id",
+                    "type": "int64"
+                  }
+                ],
+                "reserved_ids": [
+                  2
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ContainsEnum",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int32"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "NestedEnum"
+              }
+            ]
+          },
+          {
+            "name": "PreviousRequest",
+            "fields": [
+              {
+                "id": 4,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 9,
+                "name": "is_active",
+                "type": "bool"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "ChannelChanger",
+            "rpcs": [
+              {
+                "name": "Next",
+                "in_type": "NextRequest",
+                "out_type": "Channel",
+                "in_streamed": true
+              },
+              {
+                "name": "Previous",
+                "in_type": "PreviousRequest",
+                "out_type": "Channel",
+                "out_streamed": true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
@nilslice Using a struct to contain the `protopath` and `def` seems to be enough to produce a deterministic `proto.lock` file.

This can be tested by running:
- `go run cmd/protolock/main.go init` (if no `proto.lock` file is already present)
- Continually run `go run cmd/protolock/main.go commit` to generate a new lock file.  The files and properties remain ordered from the last init/commit
