### PR TITLE
expose parse

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -100,7 +100,7 @@ var (
 	svcs  []Service
 )
 
-func parse(r io.Reader) (Entry, error) {
+func Parse(r io.Reader) (Entry, error) {
 	parser := proto.NewParser(r)
 	def, err := parser.Parse()
 	if err != nil {
@@ -419,7 +419,7 @@ func getUpdatedLock(ignores string) (*Protolock, error) {
 			return nil, err
 		}
 
-		entry, err := parse(f)
+		entry, err := Parse(f)
 		if err != nil {
 			printIfErr(f.Close())
 			return nil, err

--- a/rules_test.go
+++ b/rules_test.go
@@ -684,7 +684,7 @@ message B {
 
 func TestParseOnReader(t *testing.T) {
 	r := strings.NewReader(simpleProto)
-	_, err := parse(r)
+	_, err := Parse(r)
 	assert.NoError(t, err)
 }
 
@@ -821,7 +821,7 @@ func TestShouldConflictReusingFieldsNestedMessages(t *testing.T) {
 
 func parseTestProto(t *testing.T, proto string) Protolock {
 	r := strings.NewReader(proto)
-	entry, err := parse(r)
+	entry, err := Parse(r)
 	assert.NoError(t, err)
 	return Protolock{
 		Definitions: []Definition{


### PR DESCRIPTION
Expose `parse` function so that we can write plugin tests like:
https://github.com/nilslice/protolock/blob/a13e69dbee39e4aa9d19c333ca4046a89b941603/rules_test.go#L832-L840

https://github.com/nilslice/protolock/blob/a13e69dbee39e4aa9d19c333ca4046a89b941603/rules_test.go#L842-L854