### PR TITLE
parse: added support for normal, map, and enum field options

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -23,7 +23,7 @@ message Channel {
 }
 `
 
-const protoWithOptions = `
+const protoWithMessageOptions = `
 syntax = "proto3";
 
 package test;
@@ -33,6 +33,33 @@ message Channel {
   int64 id = 1;
   string name = 2;
   string description = 3;
+}
+`
+
+const protoWithFieldOptions = `
+syntax = "proto3";
+
+package test;
+
+message Channel {
+  int64 id = 1;
+  string name = 2 [(personal) = true, (owner) = 'test'];
+  string description = 3;
+  map<string, int32> attributes = 4 [(personal) = true];
+}
+`
+
+const protoWithEnumFieldOptions = `
+syntax = "proto3";
+
+package test;
+
+enum TestEnumOption {
+  reserved 2;
+  option allow_alias = true;
+  FIRST = 0;
+  SECOND = 1;
+  SEGUNDO = 1 [(my_enum_value_option) = 321];
 }
 `
 
@@ -74,14 +101,49 @@ func TestParseIncludingImports(t *testing.T) {
 	assert.Equal(t, "testdata/test.proto", entry.Imports[0].Path)
 }
 
-func TestParseIncludingOptions(t *testing.T) {
-	r := strings.NewReader(protoWithOptions)
+func TestParseIncludingMessageOptions(t *testing.T) {
+	r := strings.NewReader(protoWithMessageOptions)
 
 	entry, err := Parse(r)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "(ext.persisted)", entry.Messages[0].Options[0].Name)
 	assert.Equal(t, "true", entry.Messages[0].Options[0].Value)
+}
+
+func TestParseIncludingFieldOptions(t *testing.T) {
+	r := strings.NewReader(protoWithFieldOptions)
+
+	entry, err := Parse(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "(personal)", entry.Messages[0].Fields[1].Options[0].Name)
+	assert.Equal(t, "true", entry.Messages[0].Fields[1].Options[0].Value)
+	assert.Equal(t, "(owner)", entry.Messages[0].Fields[1].Options[1].Name)
+	assert.Equal(t, "test", entry.Messages[0].Fields[1].Options[1].Value)
+	assert.Len(t, entry.Messages[0].Maps, 1)
+	assert.Equal(t, "string", entry.Messages[0].Maps[0].KeyType)
+	assert.Equal(t, "attributes", entry.Messages[0].Maps[0].Field.Name)
+	assert.Len(t, entry.Messages[0].Maps[0].Field.Options, 1)
+	assert.Equal(t, "(personal)", entry.Messages[0].Maps[0].Field.Options[0].Name)
+	assert.Equal(t, "true", entry.Messages[0].Maps[0].Field.Options[0].Value)
+}
+
+func TestParseIncludingEnumFieldOptions(t *testing.T) {
+	r := strings.NewReader(protoWithEnumFieldOptions)
+
+	entry, err := Parse(r)
+	assert.NoError(t, err)
+
+	assert.Len(t, entry.Enums, 1)
+	assert.Equal(t, "TestEnumOption", entry.Enums[0].Name)
+	assert.Len(t, entry.Enums[0].EnumFields, 3)
+	assert.Equal(t, "FIRST", entry.Enums[0].EnumFields[0].Name)
+	assert.Equal(t, "SECOND", entry.Enums[0].EnumFields[1].Name)
+	assert.Equal(t, "SEGUNDO", entry.Enums[0].EnumFields[2].Name)
+	assert.Len(t, entry.Enums[0].EnumFields[2].Options, 1)
+	assert.Equal(t, "(my_enum_value_option)", entry.Enums[0].EnumFields[2].Options[0].Name)
+	assert.Equal(t, "321", entry.Enums[0].EnumFields[2].Options[0].Value)
 }
 
 func TestGetProtoFilesFiltersDirectories(t *testing.T) {

--- a/proto.lock
+++ b/proto.lock
@@ -71,6 +71,33 @@
     {
       "protopath": "testdata:/:imports_options.proto",
       "def": {
+        "enums": [
+          {
+            "name": "TestEnumOption",
+            "enum_fields": [
+              {
+                "name": "FIRST"
+              },
+              {
+                "name": "SECOND",
+                "integer": 1
+              },
+              {
+                "name": "SEGUNDO",
+                "integer": 3,
+                "options": [
+                  {
+                    "name": "(my_enum_value_option)",
+                    "value": "321"
+                  }
+                ]
+              }
+            ],
+            "reserved_ids": [
+              2
+            ]
+          }
+        ],
         "messages": [
           {
             "name": "Channel",
@@ -103,12 +130,38 @@
               {
                 "id": 2,
                 "name": "name",
-                "type": "string"
+                "type": "string",
+                "options": [
+                  {
+                    "name": "(personal)",
+                    "value": "true"
+                  },
+                  {
+                    "name": "(owner)",
+                    "value": "test"
+                  }
+                ]
               },
               {
                 "id": 3,
                 "name": "description",
                 "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 4,
+                  "name": "map",
+                  "type": "int32",
+                  "options": [
+                    {
+                      "name": "(personal)",
+                      "value": "true"
+                    }
+                  ]
+                }
               }
             ],
             "options": [

--- a/testdata/imports_options.proto
+++ b/testdata/imports_options.proto
@@ -12,6 +12,15 @@ message Channel {
 message Channel2 {
   option (ext.persisted) = true;
   int64 id = 1;
-  string name = 2;
+  string name = 2 [(personal) = true, (owner) = 'test'];
   string description = 3;
+  map<string, int32> map = 4 [(personal) = true];
+}
+
+enum TestEnumOption {
+  reserved 2;
+  option allow_alias = true;
+  FIRST = 0;
+  SECOND = 1;
+  SEGUNDO = 3 [(my_enum_value_option) = 321];
 }


### PR DESCRIPTION
Credit to @aroch for the original PR (#70). Thanks for the contribution!