### PR TITLE
expose 'protoroot' and 'lockdir' as CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Options:
 	--ignore 		comma-separated list of filepaths to ignore
 	--force [false]		forces commit to rewrite proto.lock file and disregards warnings
 	--plugins               comma-separated list of executable protolock plugin names
+	--lockdir [.]		directory of proto.lock file
+	--protoroot [.]		root of directory tree containing proto files
 ```
 
 ## Related Projects & Users

--- a/commit.go
+++ b/commit.go
@@ -8,13 +8,13 @@ import (
 
 // Commit will return an io.Reader with the lock representation data for caller to
 // use as needed.
-func Commit(ignore string) (io.Reader, error) {
-	if _, err := os.Stat(LockFileName); err != nil && os.IsNotExist(err) {
+func Commit(cfg Config) (io.Reader, error) {
+	if !cfg.LockFileExists() {
 		fmt.Println(`no "proto.lock" file found, first run "init"`)
 		os.Exit(1)
 	}
 
-	updated, err := getUpdatedLock(ignore)
+	updated, err := getUpdatedLock(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/config.go
+++ b/config.go
@@ -1,0 +1,38 @@
+package protolock
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type Config struct {
+	LockDir   string
+	ProtoRoot string
+	Ignore    string
+}
+
+func NewConfig(lockDir, protoRoot, ignores string) (*Config, error) {
+	l, err := filepath.Abs(lockDir)
+	if err != nil {
+		return nil, err
+	}
+	p, err := filepath.Abs(protoRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Config{
+		LockDir:   l,
+		ProtoRoot: p,
+		Ignore:    ignores,
+	}, nil
+}
+
+func (cfg *Config) LockFileExists() bool {
+	_, err := os.Stat(cfg.LockFilePath())
+	return err == nil && !os.IsNotExist(err)
+}
+
+func (cfg *Config) LockFilePath() string {
+	return filepath.Join(cfg.LockDir, LockFileName)
+}

--- a/init.go
+++ b/init.go
@@ -12,13 +12,13 @@ const protoSuffix = ".proto"
 
 // Init will return an io.Reader with the lock representation data for caller to
 // use as needed.
-func Init(ignore string) (io.Reader, error) {
-	if _, err := os.Stat(LockFileName); err == nil && !os.IsNotExist(err) {
+func Init(cfg Config) (io.Reader, error) {
+	if cfg.LockFileExists() {
 		fmt.Println(`a "proto.lock" file was already found, use "commit" to update`)
 		os.Exit(1)
 	}
 
-	updated, err := getUpdatedLock(ignore)
+	updated, err := getUpdatedLock(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/order_test.go
+++ b/order_test.go
@@ -11,15 +11,18 @@ import (
 const ignoreArg = ""
 
 func TestOrder(t *testing.T) {
+	cfg, err := NewConfig(".", ".", ignoreArg)
+	assert.NoError(t, err)
+
 	// verify that the re-production of the same Protolock encoded as json
 	// is equivalent to any previously encoded version of the same Protolock
-	f, err := os.Open("proto.lock")
+	f, err := os.Open(cfg.LockFilePath())
 	assert.NoError(t, err)
 
 	current, err := protolockFromReader(f)
 	assert.NoError(t, err)
 
-	r, err := Commit(ignoreArg)
+	r, err := Commit(*cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 

--- a/parse.go
+++ b/parse.go
@@ -367,8 +367,8 @@ func withImport(im *proto.Import) {
 }
 
 // openLockFile opens and returns the lock file on disk for reading.
-func openLockFile() (io.ReadCloser, error) {
-	f, err := os.Open(LockFileName)
+func openLockFile(cfg Config) (io.ReadCloser, error) {
+	f, err := os.Open(cfg.LockFilePath())
 	if err != nil {
 		return nil, err
 	}
@@ -468,16 +468,16 @@ func getProtoFiles(root string, ignores string) ([]string, error) {
 
 // getUpdatedLock finds all .proto files recursively in tree, parse each file
 // and accumulate all definitions into an updated Protolock.
-func getUpdatedLock(ignores string) (*Protolock, error) {
+func getUpdatedLock(cfg Config) (*Protolock, error) {
 	// files is a slice of struct `ProtoFile` to be joined into the proto.lock file.
 	var files []ProtoFile
 
-	root, err := os.Getwd()
+	root, err := filepath.Abs(cfg.ProtoRoot)
 	if err != nil {
 		return nil, err
 	}
 
-	protoFiles, err := getProtoFiles(root, ignores)
+	protoFiles, err := getProtoFiles(root, cfg.Ignore)
 	if err != nil {
 		return nil, err
 	}

--- a/status.go
+++ b/status.go
@@ -7,13 +7,13 @@ import (
 
 // Status will report on any issues encountered when comparing the updated tree
 // of parsed proto files and the current proto.lock file.
-func Status(ignore string) (*Report, error) {
-	updated, err := getUpdatedLock(ignore)
+func Status(cfg Config) (*Report, error) {
+	updated, err := getUpdatedLock(cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	lockFile, err := openLockFile()
+	lockFile, err := openLockFile(cfg)
 	if err != nil {
 		if os.IsNotExist(err) {
 			msg := `no "proto.lock" file found, first run "init"`


### PR DESCRIPTION
👋 hey there. thanks for this delightful piece of software.

this pr exposes as CLI flags (1) the directory of the proto.lock file and (2) the root of the directory tree containing proto files.

Is this an acceptable extension? @nilslice 