### PR TITLE
added support for nested message & field options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ plugin-samples/plugin-sample-js/etc
 plugin-samples/plugin-sample-js/plugin-sample-js
 plugin-samples/plugin-sample-js/package-lock.json
 package-lock.json
+.vscode

--- a/parse.go
+++ b/parse.go
@@ -37,8 +37,9 @@ type Import struct {
 }
 
 type Option struct {
-	Name  string `json:"name,omitempty"`
-	Value string `json:"value,omitempty"`
+	Name             string   `json:"name,omitempty"`
+	Value            string   `json:"value,omitempty"`
+	AggregatedValues []Option `json:"values,omitempty"`
 }
 
 type Message struct {
@@ -326,10 +327,7 @@ func parseMessage(m *proto.Message) Message {
 		}
 
 		if o, ok := v.(*proto.Option); ok {
-			msg.Options = append(msg.Options, Option{
-				Name:  o.Name,
-				Value: o.Constant.Source,
-			})
+			msg.Options = append(msg.Options, parseOption(o))
 		}
 
 		if m, ok := v.(*proto.Message); ok {
@@ -343,12 +341,36 @@ func parseMessage(m *proto.Message) Message {
 func parseOptions(opts []*proto.Option) []Option {
 	var msgOpts []Option
 	for _, o := range opts {
-		msgOpts = append(msgOpts, Option{
-			Name:  o.Name,
-			Value: o.Constant.Source,
-		})
+		msgOpts = append(msgOpts, parseOption(o))
 	}
 	return msgOpts
+}
+
+func parseOption(o *proto.Option) Option {
+	option := Option{
+		Name: o.Name,
+	}
+	if isAggregatedOption(o) {
+		option.AggregatedValues = parseAggregatedValues(o)
+	} else {
+		option.Value = o.Constant.Source
+	}
+	return option
+}
+
+func parseAggregatedValues(o *proto.Option) []Option {
+	var aggOpts []Option
+	for _, nl := range o.Constant.OrderedMap {
+		aggOpts = append(aggOpts, Option{
+			Name:  nl.Name,
+			Value: nl.Source,
+		})
+	}
+	return aggOpts
+}
+
+func isAggregatedOption(o *proto.Option) bool {
+	return o.Constant.Source == "" && o.Constant.OrderedMap != nil
 }
 
 func protoWithImport(apply func(p *proto.Import)) proto.Handler {

--- a/parse_test.go
+++ b/parse_test.go
@@ -36,6 +36,19 @@ message Channel {
 }
 `
 
+const protoWithNestedMessageOptions = `
+syntax = "proto3";
+
+package test;
+
+message Channel {
+  option (ext.persisted) = { opt1: true opt2: false };
+  int64 id = 1;
+  string name = 2;
+  string description = 3;
+}
+`
+
 const protoWithFieldOptions = `
 syntax = "proto3";
 
@@ -46,6 +59,34 @@ message Channel {
   string name = 2 [(personal) = true, (owner) = 'test'];
   string description = 3;
   map<string, int32> attributes = 4 [(personal) = true];
+}
+`
+
+const protoWithNestedFieldOptions = `
+syntax = "proto3";
+
+package test;
+
+message Channel {
+ int64 id = 1;
+ string name = 2;
+ string description = 3;
+ map<string, int32> attributes = 4;
+ string address = 5 [(custom_options).personal = true, (custom_options).internal = false];
+}
+`
+
+const protoWithNestedFieldOptionsAggregated = `
+syntax = "proto3";
+
+package test;
+
+message Channel {
+  int64 id = 1;
+  string name = 2;
+  string description = 3 [(custom_options_commas) = { personal: true, internal: false, owner: "some owner" }];
+  map<string, int32> attributes = 4;
+  string address = 5 [(custom_options) = { personal: true internal: false owner: "some owner" }];
 }
 `
 
@@ -111,6 +152,21 @@ func TestParseIncludingMessageOptions(t *testing.T) {
 	assert.Equal(t, "true", entry.Messages[0].Options[0].Value)
 }
 
+func TestParseIncludingNestedMessageOptions(t *testing.T) {
+	r := strings.NewReader(protoWithNestedMessageOptions)
+
+	entry, err := Parse(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "(ext.persisted)", entry.Messages[0].Options[0].Name)
+	assert.Empty(t, entry.Messages[0].Options[0].Value)
+	assert.Len(t, entry.Messages[0].Options[0].AggregatedValues, 2)
+	assert.Equal(t, "opt1", entry.Messages[0].Options[0].AggregatedValues[0].Name)
+	assert.Equal(t, "true", entry.Messages[0].Options[0].AggregatedValues[0].Value)
+	assert.Equal(t, "opt2", entry.Messages[0].Options[0].AggregatedValues[1].Name)
+	assert.Equal(t, "false", entry.Messages[0].Options[0].AggregatedValues[1].Value)
+}
+
 func TestParseIncludingFieldOptions(t *testing.T) {
 	r := strings.NewReader(protoWithFieldOptions)
 
@@ -127,6 +183,43 @@ func TestParseIncludingFieldOptions(t *testing.T) {
 	assert.Len(t, entry.Messages[0].Maps[0].Field.Options, 1)
 	assert.Equal(t, "(personal)", entry.Messages[0].Maps[0].Field.Options[0].Name)
 	assert.Equal(t, "true", entry.Messages[0].Maps[0].Field.Options[0].Value)
+}
+
+func TestParseIncludingNestedFieldOptions(t *testing.T) {
+	r := strings.NewReader(protoWithNestedFieldOptions)
+
+	entry, err := Parse(r)
+	assert.NoError(t, err)
+
+	assert.Len(t, entry.Messages[0].Fields[3].Options, 2)
+	assert.Equal(t, "(custom_options).personal", entry.Messages[0].Fields[3].Options[0].Name)
+	assert.Equal(t, "true", entry.Messages[0].Fields[3].Options[0].Value)
+	assert.Equal(t, "(custom_options).internal", entry.Messages[0].Fields[3].Options[1].Name)
+	assert.Equal(t, "false", entry.Messages[0].Fields[3].Options[1].Value)
+}
+
+func TestParseIncludingNestedFieldOptionsAggregated(t *testing.T) {
+	r := strings.NewReader(protoWithNestedFieldOptionsAggregated)
+
+	entry, err := Parse(r)
+	assert.NoError(t, err)
+
+	assert.Len(t, entry.Messages[0].Fields[2].Options, 1)
+	assert.Equal(t, "(custom_options_commas)", entry.Messages[0].Fields[2].Options[0].Name)
+	assert.Equal(t, "personal", entry.Messages[0].Fields[2].Options[0].AggregatedValues[0].Name)
+	assert.Equal(t, "true", entry.Messages[0].Fields[2].Options[0].AggregatedValues[0].Value)
+	assert.Equal(t, "internal", entry.Messages[0].Fields[2].Options[0].AggregatedValues[1].Name)
+	assert.Equal(t, "false", entry.Messages[0].Fields[2].Options[0].AggregatedValues[1].Value)
+	assert.Equal(t, "owner", entry.Messages[0].Fields[2].Options[0].AggregatedValues[2].Name)
+	assert.Equal(t, "some owner", entry.Messages[0].Fields[2].Options[0].AggregatedValues[2].Value)
+	assert.Len(t, entry.Messages[0].Fields[3].Options, 1)
+	assert.Equal(t, "(custom_options)", entry.Messages[0].Fields[3].Options[0].Name)
+	assert.Equal(t, "personal", entry.Messages[0].Fields[3].Options[0].AggregatedValues[0].Name)
+	assert.Equal(t, "true", entry.Messages[0].Fields[3].Options[0].AggregatedValues[0].Value)
+	assert.Equal(t, "internal", entry.Messages[0].Fields[3].Options[0].AggregatedValues[1].Name)
+	assert.Equal(t, "false", entry.Messages[0].Fields[3].Options[0].AggregatedValues[1].Value)
+	assert.Equal(t, "owner", entry.Messages[0].Fields[3].Options[0].AggregatedValues[2].Name)
+	assert.Equal(t, "some owner", entry.Messages[0].Fields[3].Options[0].AggregatedValues[2].Value)
 }
 
 func TestParseIncludingEnumFieldOptions(t *testing.T) {

--- a/proto.lock
+++ b/proto.lock
@@ -117,6 +117,21 @@
                 "name": "description",
                 "type": "string"
               }
+            ],
+            "options": [
+              {
+                "name": "(ext.persisted)",
+                "values": [
+                  {
+                    "name": "opt1",
+                    "value": "true"
+                  },
+                  {
+                    "name": "opt2",
+                    "value": "false"
+                  }
+                ]
+              }
             ]
           },
           {
@@ -145,7 +160,50 @@
               {
                 "id": 3,
                 "name": "description",
-                "type": "string"
+                "type": "string",
+                "options": [
+                  {
+                    "name": "(custom_options_commas)",
+                    "values": [
+                      {
+                        "name": "personal",
+                        "value": "true"
+                      },
+                      {
+                        "name": "internal",
+                        "value": "false"
+                      },
+                      {
+                        "name": "owner",
+                        "value": "some owner"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "id": 5,
+                "name": "address",
+                "type": "string",
+                "options": [
+                  {
+                    "name": "(custom_options)",
+                    "values": [
+                      {
+                        "name": "personal",
+                        "value": "true"
+                      },
+                      {
+                        "name": "internal",
+                        "value": "false"
+                      },
+                      {
+                        "name": "owner",
+                        "value": "some owner"
+                      }
+                    ]
+                  }
+                ]
               }
             ],
             "maps": [
@@ -170,9 +228,42 @@
                 "value": "true"
               }
             ]
+          },
+          {
+            "name": "FieldOptions",
+            "fields": [
+              {
+                "id": 1,
+                "name": "personal",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "internal",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "owner",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "google.protobuf.FieldOptions",
+            "fields": [
+              {
+                "id": 50000,
+                "name": "custom_options",
+                "type": "FieldOptions"
+              }
+            ]
           }
         ],
         "imports": [
+          {
+            "path": "google/protobuf/descriptor.proto"
+          },
           {
             "path": "testdata/test.proto"
           }

--- a/testdata/imports_options.proto
+++ b/testdata/imports_options.proto
@@ -1,9 +1,11 @@
 syntax = "proto3";
 package test;
 
+import "google/protobuf/descriptor.proto";
 import "testdata/test.proto";
 
 message Channel {
+  option (ext.persisted) = { opt1: true opt2: false };
   int64 id = 1;
   string name = 2;
   string description = 3;
@@ -13,8 +15,9 @@ message Channel2 {
   option (ext.persisted) = true;
   int64 id = 1;
   string name = 2 [(personal) = true, (owner) = 'test'];
-  string description = 3;
+  string description = 3 [(custom_options_commas) = { personal: true, internal: false, owner: "some owner" }];
   map<string, int32> map = 4 [(personal) = true];
+  string address = 5 [(custom_options) = { personal: true internal: false owner: "some owner" }];
 }
 
 enum TestEnumOption {
@@ -23,4 +26,14 @@ enum TestEnumOption {
   FIRST = 0;
   SECOND = 1;
   SEGUNDO = 3 [(my_enum_value_option) = 321];
+}
+
+message FieldOptions {
+  bool personal = 1;
+  bool internal = 2;
+  string owner = 3;
+}
+
+extend google.protobuf.FieldOptions {
+  FieldOptions custom_options = 50000;
 }


### PR DESCRIPTION
I would like to add support for [Custom Options](https://developers.google.com/protocol-buffers/docs/proto#options) with a sub-message.

Our use-case is GDPR. We're marking fields in the protobuf as 'private data' for further use down the line. We use custom option with a sub-message.

From the Protobuf docs, it would look something like:

```
message FooOptions {
  optional int32 opt1 = 1;
  optional string opt2 = 2;
}

extend google.protobuf.FieldOptions {
  optional FooOptions foo_options = 1234;
}

// usage:
message Bar {
  optional int32 b = 1 [(foo_options) = { opt1: 123 opt2: "baz" }];
}
```

This could be parsed as follows:

```
{
  "id": 1,
  "name": "b",
  "type": "string",
  "options": [
    {
      "name": "(foo_options)",
      "values": [
        {
          "name": "opt1",
          "value": "true"
        },
        {
          "name": "opt2",
          "value": "true"
        }
      ]
    }
  ]
}
```

It's a bit tricky to model this... I propose to add to the Option struct a new attribute called NestedOptions that would map to json 'values':

```
type Option struct {
	Name          string   `json:"name,omitempty"`
	Value         string   `json:"value,omitempty"`
	NestedOptions []Option `json:"values,omitempty"`
}
```

Please let me know your thoughts.

Rafi