### PR TITLE
added parsing of packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ plugin-samples/plugin-sample-js/plugin-sample-js
 plugin-samples/plugin-sample-js/package-lock.json
 package-lock.json
 .vscode
+.idea

--- a/parse.go
+++ b/parse.go
@@ -30,10 +30,15 @@ type Entry struct {
 	Messages []Message `json:"messages,omitempty"`
 	Services []Service `json:"services,omitempty"`
 	Imports  []Import  `json:"imports,omitempty"`
+	Package  Package   `json:"package,omitempty"`
 }
 
 type Import struct {
 	Path string `json:"path,omitempty"`
+}
+
+type Package struct {
+	Name string `json:"name,omitempty"`
 }
 
 type Option struct {
@@ -114,6 +119,7 @@ var (
 	msgs  []Message
 	svcs  []Service
 	imps  []Import
+	pkg   Package
 
 	ErrWarningsFound = errors.New("comparison found one or more warnings")
 )
@@ -136,6 +142,7 @@ func Parse(r io.Reader) (Entry, error) {
 		proto.WithService(withService),
 		proto.WithMessage(withMessage),
 		protoWithImport(withImport),
+		protoWithPackage(withPackage),
 	)
 
 	return Entry{
@@ -143,6 +150,7 @@ func Parse(r io.Reader) (Entry, error) {
 		Messages: msgs,
 		Services: svcs,
 		Imports:  imps,
+		Package:  pkg,
 	}, nil
 }
 
@@ -386,6 +394,20 @@ func withImport(im *proto.Import) {
 		Path: im.Filename,
 	}
 	imps = append(imps, imp)
+}
+
+func protoWithPackage(apply func(p *proto.Package)) proto.Handler {
+	return func(v proto.Visitee) {
+		if s, ok := v.(*proto.Package); ok {
+			apply(s)
+		}
+	}
+}
+
+func withPackage(im *proto.Package) {
+	pkg = Package{
+		Name: im.Name,
+	}
 }
 
 // openLockFile opens and returns the lock file on disk for reading.

--- a/parse_test.go
+++ b/parse_test.go
@@ -23,6 +23,19 @@ message Channel {
 }
 `
 
+const protoWithPackages = `
+syntax = "proto3";
+
+import "testdata/test.proto";
+
+package test;
+
+message Channel {
+  int64 id = 1;
+  string name = 2;
+  string description = 3;
+}
+`
 const protoWithMessageOptions = `
 syntax = "proto3";
 
@@ -140,6 +153,15 @@ func TestParseIncludingImports(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, "testdata/test.proto", entry.Imports[0].Path)
+}
+
+func TestParseIncludingPackage(t *testing.T) {
+	r := strings.NewReader(protoWithPackages)
+
+	entry, err := Parse(r)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "test", entry.Package.Name)
 }
 
 func TestParseIncludingMessageOptions(t *testing.T) {

--- a/proto.lock
+++ b/proto.lock
@@ -14,7 +14,10 @@
               }
             ]
           }
-        ]
+        ],
+        "package": {
+          "name": "exclude"
+        }
       }
     },
     {
@@ -31,7 +34,10 @@
               }
             ]
           }
-        ]
+        ],
+        "package": {
+          "name": "exclude"
+        }
       }
     },
     {
@@ -48,7 +54,10 @@
               }
             ]
           }
-        ]
+        ],
+        "package": {
+          "name": "exclude"
+        }
       }
     },
     {
@@ -65,7 +74,10 @@
               }
             ]
           }
-        ]
+        ],
+        "package": {
+          "name": "include"
+        }
       }
     },
     {
@@ -267,7 +279,10 @@
           {
             "path": "testdata/test.proto"
           }
-        ]
+        ],
+        "package": {
+          "name": "test"
+        }
       }
     },
     {
@@ -469,7 +484,10 @@
               }
             ]
           }
-        ]
+        ],
+        "package": {
+          "name": "dataset"
+        }
       }
     }
   ]


### PR DESCRIPTION
It's helpful to know the packages for each definition. This way you can navigate from definition to another by package name.
Also, sometimes different definitions share the same package name and that's a valuable information to have in your lock file.
