### PR TITLE
main: ordering warning messages for a consistent output

### DIFF
--- a/cmd/protolock/main.go
+++ b/cmd/protolock/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 
 	"github.com/nilslice/protolock"
 )
@@ -135,6 +136,9 @@ func main() {
 
 func handleReport(report *protolock.Report, err error) {
 	if len(report.Warnings) > 0 {
+
+		orderByPathAndMessage(report.Warnings)
+
 		for _, w := range report.Warnings {
 			fmt.Fprintf(
 				os.Stdout,
@@ -148,6 +152,18 @@ func handleReport(report *protolock.Report, err error) {
 	if err != nil {
 		fmt.Println(err)
 	}
+}
+
+func orderByPathAndMessage(warnings []protolock.Warning) {
+	sort.Slice(warnings, func(i, j int) bool {
+		if warnings[i].Filepath < warnings[j].Filepath {
+			return true
+		}
+		if warnings[i].Filepath > warnings[j].Filepath {
+			return false
+		}
+		return warnings[i].Message < warnings[j].Message
+	})
 }
 
 func saveToLockFile(cfg protolock.Config, r io.Reader) error {


### PR DESCRIPTION
Currently the order of printed CONFLICT messages is random.
This is as a result of the randomness of iterating map types and the asynchronous manner we run the rules & plugins.
I suggest to sort the warnings before they are printed by Path and then by Message.
This way we get consistent output after each run.

Let me know what you think.