### PR TITLE
Fixing and issue with the parsing logic's handing of path separators

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -495,7 +495,7 @@ func getProtoFiles(root string, ignores string) ([]string, error) {
 					return nil
 				}
 
-				if !strings.HasPrefix(rel, "../") {
+				if !strings.HasPrefix(rel, ".." + string(os.PathSeparator)) {
 					return nil
 				}
 			}


### PR DESCRIPTION
This caused issues on Windows.