### PR TITLE
plugins: add support for protolock warnings passed to plugins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,15 @@ jobs:
             if [ "$MOREERRS" != 3 ]; then
               exit 1
             fi
+      - run: 
+          name: remove a test proto file, expect violations.txt to contain data from plugin-sample
+          command: |
+            set +o pipefail
+
+            rm testdata/test.proto
+            protolock status --plugins=plugin-sample || true # let this fail, don't stop CI
+            stat violations.txt
+            cat violations.txt | grep "Encountered changes in violation of: NoRemovingFieldsWithoutReserve"
             
   plugin_nodejs:
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-./protolock
+protolock
 pkg
 node_modules
 plugin-samples/plugin-sample-js/etc
@@ -7,3 +7,4 @@ plugin-samples/plugin-sample-js/package-lock.json
 package-lock.json
 .vscode
 .idea
+violations.txt

--- a/cmd/protolock/main.go
+++ b/cmd/protolock/main.go
@@ -131,7 +131,7 @@ func status(cfg *protolock.Config) {
 
 func handleReport(report *protolock.Report, err error) {
 	if len(report.Warnings) > 0 {
-
+		// sort the warnings so they are grouped by file location
 		orderByPathAndMessage(report.Warnings)
 
 		for _, w := range report.Warnings {

--- a/cmd/protolock/plugins.go
+++ b/cmd/protolock/plugins.go
@@ -17,9 +17,10 @@ func runPlugins(pluginList string, report *protolock.Report) (*protolock.Report,
 	inputData := &bytes.Buffer{}
 
 	err := json.NewEncoder(inputData).Encode(&extend.Data{
-		Current:        report.Current,
-		Updated:        report.Updated,
-		PluginWarnings: []protolock.Warning{},
+		Current:           report.Current,
+		Updated:           report.Updated,
+		ProtolockWarnings: report.Warnings,
+		PluginWarnings:    []protolock.Warning{},
 	})
 	if err != nil {
 		return nil, err

--- a/extend/plugin.go
+++ b/extend/plugin.go
@@ -21,6 +21,7 @@ type Plugin interface {
 type Data struct {
 	Current            protolock.Protolock `json:"current,omitempty"`
 	Updated            protolock.Protolock `json:"updated,omitempty"`
+	ProtolockWarnings  []protolock.Warning `json:"protolock_warnings,omitempty"`
 	PluginWarnings     []protolock.Warning `json:"plugin_warnings,omitempty"`
 	PluginErrorMessage string              `json:"plugin_error_message,omitempty"`
 }

--- a/parse.go
+++ b/parse.go
@@ -108,6 +108,7 @@ type Report struct {
 type Warning struct {
 	Filepath Protopath `json:"filepath,omitempty"`
 	Message  string    `json:"message,omitempty"`
+	RuleName string    `json:"rulename,omitempty"`
 }
 
 type ProtoFile struct {
@@ -449,12 +450,21 @@ func compare(current, update Protolock) (*Report, error) {
 		Current: current,
 		Updated: update,
 	}
-	for _, fn := range ruleFuncs {
+	for _, rule := range Rules {
 		wg.Add(1)
 		go func() {
-			if w, ok := fn(current, update); !ok {
-				warnings = append(warnings, w...)
+			if debug {
+				beginRuleDebug(rule.Name)
 			}
+			_warnings, _ := rule.Func(current, update)
+			for _, w := range _warnings {
+				w.RuleName = rule.Name
+			}
+			if debug {
+				concludeRuleDebug(rule.Name, _warnings)
+			}
+
+			warnings = append(warnings, _warnings...)
 			wg.Done()
 		}()
 		wg.Wait()

--- a/parse.go
+++ b/parse.go
@@ -457,8 +457,8 @@ func compare(current, update Protolock) (*Report, error) {
 				beginRuleDebug(rule.Name)
 			}
 			_warnings, _ := rule.Func(current, update)
-			for _, w := range _warnings {
-				w.RuleName = rule.Name
+			for i := range _warnings {
+				_warnings[i].RuleName = rule.Name
 			}
 			if debug {
 				concludeRuleDebug(rule.Name, _warnings)
@@ -505,7 +505,7 @@ func getProtoFiles(root string, ignores string) ([]string, error) {
 					return nil
 				}
 
-				if !strings.HasPrefix(rel, ".." + string(os.PathSeparator)) {
+				if !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 					return nil
 				}
 			}

--- a/plugin-samples/plugin-sample-js/main.js
+++ b/plugin-samples/plugin-sample-js/main.js
@@ -2,9 +2,15 @@
 let data = {
     current: {},
     updated: {},
+    protolock_warnings: [{
+        filepath: "",
+        message: "",
+        name: "",
+    }],
     plugin_warnings: [{
         filepath: "",
         message: "",
+        name: "",
     }],
     plugin_error_message: "",
 }

--- a/plugin-samples/plugin-sample/main.go
+++ b/plugin-samples/plugin-sample/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/nilslice/protolock"
 	"github.com/nilslice/protolock/extend"
 )
@@ -8,6 +11,18 @@ import (
 func main() {
 	plugin := extend.NewPlugin("sample") // "sample" is arbitrary name used to correlate error messages
 	plugin.Init(func(data *extend.Data) *extend.Data {
+		// list all existing rules violated from warnings passed into plugin
+		// from protolock & write to output file
+		out, err := os.Create("violations.txt")
+		if err != nil {
+			return data
+		}
+		for _, w := range data.ProtolockWarnings {
+			fmt.Fprintln(
+				out, "Encountered changes in violation of:", w.RuleName,
+			)
+		}
+
 		warnings := AddWarningsForExample(data.Current, data.Updated)
 		data.PluginWarnings = append(data.PluginWarnings, warnings...)
 		return data
@@ -16,7 +31,13 @@ func main() {
 
 func AddWarningsForExample(cur, upd protolock.Protolock) []protolock.Warning {
 	return []protolock.Warning{
-		{Filepath: protolock.OSPath(upd.Definitions[0].Filepath), Message: "A sample warning!"},
-		{Filepath: protolock.OSPath(upd.Definitions[0].Filepath), Message: "Another sample warning.. ah!"},
+		{
+			Filepath: protolock.OSPath(upd.Definitions[0].Filepath),
+			Message:  "A sample warning!",
+		},
+		{
+			Filepath: protolock.OSPath(upd.Definitions[0].Filepath),
+			Message:  "Another sample warning.. ah!",
+		},
 	}
 }

--- a/rules.go
+++ b/rules.go
@@ -5,18 +5,42 @@ import (
 )
 
 var (
-	// ruleFuncs provides a complete list of all funcs to be run to compare
+	// Rules provides a complete list of all funcs to be run to compare
 	// a set of Protolocks. This list should be updated as new RuleFunc's
 	// are added to this package.
-	ruleFuncs = []RuleFunc{
-		NoUsingReservedFields,
-		NoRemovingReservedFields,
-		NoRemovingFieldsWithoutReserve,
-		NoChangingFieldIDs,
-		NoChangingFieldTypes,
-		NoChangingFieldNames,
-		NoRemovingRPCs,
-		NoChangingRPCSignature,
+	Rules = []Rule{
+		{
+			Name: "NoUsingReservedFields",
+			Func: NoUsingReservedFields,
+		},
+		{
+			Name: "NoRemovingReservedFields",
+			Func: NoRemovingReservedFields,
+		},
+		{
+			Name: "NoRemovingFieldsWithoutReserve",
+			Func: NoRemovingFieldsWithoutReserve,
+		},
+		{
+			Name: "NoChangingFieldIDs",
+			Func: NoChangingFieldIDs,
+		},
+		{
+			Name: "NoChangingFieldTypes",
+			Func: NoChangingFieldTypes,
+		},
+		{
+			Name: "NoChangingFieldNames",
+			Func: NoChangingFieldNames,
+		},
+		{
+			Name: "NoRemovingRPCs",
+			Func: NoRemovingRPCs,
+		},
+		{
+			Name: "NoChangingRPCSignature",
+			Func: NoChangingRPCSignature,
+		},
 	}
 
 	strict = true
@@ -33,6 +57,11 @@ func SetStrict(mode bool) {
 // SetDebug enables the user to toggle debug mode on and off.
 func SetDebug(status bool) {
 	debug = status
+}
+
+type Rule struct {
+	Name string
+	Func RuleFunc
 }
 
 // RuleFunc defines the common signature for a function which can compare
@@ -151,10 +180,6 @@ func incEnumFields(reservedIDMap lockIDsMap, reservedNameMap lockNamesMap, filep
 // and will return a list of warnings if any message's previously reserved fields
 // or IDs are now being used as part of the same message.
 func NoUsingReservedFields(cur, upd Protolock) ([]Warning, bool) {
-	if debug {
-		beginRuleDebug("NoUsingReservedFields")
-	}
-
 	reservedIDMap, reservedNameMap := getReservedFields(cur)
 	reservedEnumIDMap, reservedEnumNameMap := getReservedEnumFields(cur)
 
@@ -272,10 +297,6 @@ func NoUsingReservedFields(cur, upd Protolock) ([]Warning, bool) {
 		}
 	}
 
-	if debug {
-		concludeRuleDebug("NoUsingReservedFields", warnings)
-	}
-
 	if warnings != nil {
 		return warnings, false
 	}
@@ -289,10 +310,6 @@ func NoUsingReservedFields(cur, upd Protolock) ([]Warning, bool) {
 func NoRemovingReservedFields(cur, upd Protolock) ([]Warning, bool) {
 	if !strict {
 		return nil, true
-	}
-
-	if debug {
-		beginRuleDebug("NoRemovingReservedFields")
 	}
 
 	var warnings []Warning
@@ -371,10 +388,6 @@ func NoRemovingReservedFields(cur, upd Protolock) ([]Warning, bool) {
 		}
 	}
 
-	if debug {
-		concludeRuleDebug("NoRemovingReservedFields", warnings)
-	}
-
 	if warnings != nil {
 		return warnings, false
 	}
@@ -385,10 +398,6 @@ func NoRemovingReservedFields(cur, upd Protolock) ([]Warning, bool) {
 // NoChangingFieldIDs compares the current vs. updated Protolock definitions and
 // will return a list of warnings if any field ID number has been changed.
 func NoChangingFieldIDs(cur, upd Protolock) ([]Warning, bool) {
-	if debug {
-		beginRuleDebug("NoChangingFieldIDs")
-	}
-
 	var warnings []Warning
 
 	// check all non-reserved message fields
@@ -443,10 +452,6 @@ func NoChangingFieldIDs(cur, upd Protolock) ([]Warning, bool) {
 		}
 	}
 
-	if debug {
-		concludeRuleDebug("NoChangingFieldIDs", warnings)
-	}
-
 	if warnings != nil {
 		return warnings, false
 	}
@@ -457,10 +462,6 @@ func NoChangingFieldIDs(cur, upd Protolock) ([]Warning, bool) {
 // NoChangingFieldTypes compares the current vs. updated Protolock definitions and
 // will return a list of warnings if any field type has been changed.
 func NoChangingFieldTypes(cur, upd Protolock) ([]Warning, bool) {
-	if debug {
-		beginRuleDebug("NoChangingFieldTypes")
-	}
-
 	curFieldMap := getFieldMap(cur)
 	updFieldMap := getFieldMap(upd)
 	curMapMap := getMapMap(cur)
@@ -521,10 +522,6 @@ func NoChangingFieldTypes(cur, upd Protolock) ([]Warning, bool) {
 		}
 	}
 
-	if debug {
-		concludeRuleDebug("NoChangingFieldTypes", warnings)
-	}
-
 	if warnings != nil {
 		return warnings, false
 	}
@@ -538,10 +535,6 @@ func NoChangingFieldTypes(cur, upd Protolock) ([]Warning, bool) {
 func NoChangingFieldNames(cur, upd Protolock) ([]Warning, bool) {
 	if !strict {
 		return nil, true
-	}
-
-	if debug {
-		beginRuleDebug("NoChangingFieldNames")
 	}
 
 	var warnings []Warning
@@ -598,10 +591,6 @@ func NoChangingFieldNames(cur, upd Protolock) ([]Warning, bool) {
 		}
 	}
 
-	if debug {
-		concludeRuleDebug("NoChangingFieldNames", warnings)
-	}
-
 	if warnings != nil {
 		return warnings, false
 	}
@@ -615,10 +604,6 @@ func NoChangingFieldNames(cur, upd Protolock) ([]Warning, bool) {
 func NoRemovingRPCs(cur, upd Protolock) ([]Warning, bool) {
 	if !strict {
 		return nil, true
-	}
-
-	if debug {
-		beginRuleDebug("NoRemovingRPCs")
 	}
 
 	var warnings []Warning
@@ -645,10 +630,6 @@ func NoRemovingRPCs(cur, upd Protolock) ([]Warning, bool) {
 		}
 	}
 
-	if debug {
-		concludeRuleDebug("NoRemovingRPCs", warnings)
-	}
-
 	if warnings != nil {
 		return warnings, false
 	}
@@ -660,10 +641,6 @@ func NoRemovingRPCs(cur, upd Protolock) ([]Warning, bool) {
 // definitions and will return a list of warnings if any field has been removed
 // without a corresponding reservation of that field name or ID.
 func NoRemovingFieldsWithoutReserve(cur, upd Protolock) ([]Warning, bool) {
-	if debug {
-		beginRuleDebug("NoRemovingFieldsWithoutReserve")
-	}
-
 	var warnings []Warning
 
 	// check all message fields
@@ -770,10 +747,6 @@ func NoRemovingFieldsWithoutReserve(cur, upd Protolock) ([]Warning, bool) {
 		}
 	}
 
-	if debug {
-		concludeRuleDebug("NoRemovingFieldsWithoutReserve", warnings)
-	}
-
 	if warnings != nil {
 		return warnings, false
 	}
@@ -785,10 +758,6 @@ func NoRemovingFieldsWithoutReserve(cur, upd Protolock) ([]Warning, bool) {
 // definitions and will return a list of warnings if any RPC signature has been
 // changed while using the same name.
 func NoChangingRPCSignature(cur, upd Protolock) ([]Warning, bool) {
-	if debug {
-		beginRuleDebug("NoChangingRPCSignature")
-	}
-
 	var warnings []Warning
 	// check that no breaking changes to the signature of an RPC have been
 	// made between the current Protolock and the updated Protolock
@@ -849,10 +818,6 @@ func NoChangingRPCSignature(cur, upd Protolock) ([]Warning, bool) {
 				}
 			}
 		}
-	}
-
-	if debug {
-		concludeRuleDebug("NoChangingRPCSignature", warnings)
 	}
 
 	if warnings != nil {


### PR DESCRIPTION
@milton0825 -- thanks for the initial work here! I added the capability for the main `protolock` process to pass plugins the existing warnings (only from top-level protolock rules), so you can implement your plugin idea mentioned in #96 

Take a look at the `plugin-sample` to see how these warnings are made available. 

Also, just a note on Go range operations, the range loop over `_warnings` was only operating on a copy of the individual warning, so the rule assignment needs to be done on the internal slice value instead (see: https://github.com/nilslice/protolock/compare/pr-96?expand=1#diff-090598d65549267a01d4ed4132809255R461). 

Please let me know if this satisfies the requirements you have for your plugin or if there is anything else to be done. 