### PR TITLE
Print the message when failed to decode

### DIFF
--- a/cmd/protolock/plugins.go
+++ b/cmd/protolock/plugins.go
@@ -89,7 +89,7 @@ func runPlugins(pluginList string, report *protolock.Report) (*protolock.Report,
 			pluginData := &extend.Data{}
 			err = json.Unmarshal(output, pluginData)
 			if err != nil {
-				fmt.Println("Get following message:", string(output))
+				fmt.Println("[protolock] Get following message:", string(output))
 				fmt.Println("[protolock] plugin data decode error:", err)
 				return
 			}

--- a/cmd/protolock/plugins.go
+++ b/cmd/protolock/plugins.go
@@ -89,6 +89,7 @@ func runPlugins(pluginList string, report *protolock.Report) (*protolock.Report,
 			pluginData := &extend.Data{}
 			err = json.Unmarshal(output, pluginData)
 			if err != nil {
+				fmt.Println("Get following message:", string(output))
 				fmt.Println("[protolock] plugin data decode error:", err)
 				return
 			}


### PR DESCRIPTION
When we failed to decode the message from plugin, it would be easier to debug if we log the message.