### PR TITLE
fixes #117 - supporting nested structures in options (arrays, maps)

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -100,6 +100,8 @@ message Channel {
   string description = 3 [(custom_options_commas) = { personal: true, internal: false, owner: "some owner" }];
   map<string, int32> attributes = 4;
   string address = 5 [(custom_options) = { personal: true internal: false owner: "some owner" }];
+  float array = 6 [(validate.rules).floats = {in: [4.56, 7.89]}];
+  float map = 7 [(validate.rules).keys = {map: { a: [4.56, 7.89], c: d}}];
 }
 `
 
@@ -269,6 +271,18 @@ func TestParseIncludingNestedFieldOptionsAggregated(t *testing.T) {
 	assert.Equal(t, "false", entry.Messages[0].Fields[3].Options[0].Aggregated[1].Value)
 	assert.Equal(t, "owner", entry.Messages[0].Fields[3].Options[0].Aggregated[2].Name)
 	assert.Equal(t, "some owner", entry.Messages[0].Fields[3].Options[0].Aggregated[2].Value)
+	assert.Equal(t, "in", entry.Messages[0].Fields[4].Options[0].Aggregated[0].Name)
+	assert.Equal(t, "", entry.Messages[0].Fields[4].Options[0].Aggregated[0].Value)
+	assert.Equal(t, "4.56", entry.Messages[0].Fields[4].Options[0].Aggregated[0].Aggregated[0].Value)
+	assert.Equal(t, "7.89", entry.Messages[0].Fields[4].Options[0].Aggregated[0].Aggregated[1].Value)
+	assert.Equal(t, "map", entry.Messages[0].Fields[5].Options[0].Aggregated[0].Name)
+	assert.Equal(t, "", entry.Messages[0].Fields[5].Options[0].Aggregated[0].Value)
+	assert.Equal(t, "a", entry.Messages[0].Fields[5].Options[0].Aggregated[0].Aggregated[0].Name)
+	assert.Equal(t, "", entry.Messages[0].Fields[5].Options[0].Aggregated[0].Aggregated[0].Value)
+	assert.Equal(t, "4.56", entry.Messages[0].Fields[5].Options[0].Aggregated[0].Aggregated[0].Aggregated[0].Value)
+	assert.Equal(t, "7.89", entry.Messages[0].Fields[5].Options[0].Aggregated[0].Aggregated[0].Aggregated[1].Value)
+	assert.Equal(t, "c", entry.Messages[0].Fields[5].Options[0].Aggregated[0].Aggregated[1].Name)
+	assert.Equal(t, "d", entry.Messages[0].Fields[5].Options[0].Aggregated[0].Aggregated[1].Value)
 }
 
 func TestParseIncludingEnumFieldOptions(t *testing.T) {

--- a/proto.lock
+++ b/proto.lock
@@ -212,6 +212,30 @@
                       {
                         "name": "owner",
                         "value": "some owner"
+                      },
+                      {
+                        "name": "arr",
+                        "aggregated": [
+                          {
+                            "value": "1.2"
+                          },
+                          {
+                            "value": "3.4"
+                          }
+                        ]
+                      },
+                      {
+                        "name": "map",
+                        "aggregated": [
+                          {
+                            "name": "a",
+                            "value": "b"
+                          },
+                          {
+                            "name": "c",
+                            "value": "d"
+                          }
+                        ]
                       }
                     ]
                   }

--- a/testdata/imports_options.proto
+++ b/testdata/imports_options.proto
@@ -17,7 +17,7 @@ message Channel2 {
   string name = 2 [(personal) = true, (owner) = 'test'];
   string description = 3 [(custom_options_commas) = { personal: true, internal: false, owner: "some owner" }];
   map<string, int32> map = 4 [(personal) = true];
-  string address = 5 [(custom_options) = { personal: true internal: false owner: "some owner" }];
+  string address = 5 [(custom_options) = { personal: true internal: false owner: "some owner", arr: [1.2, 3.4], map: { a:b, c:d } }];
 }
 
 enum TestEnumOption {


### PR DESCRIPTION
This will add support for nested structures like arrays and maps:

`string address = 5 [(custom_options) = { arr: [1.2, 3.4], map: { a:b, c:[5.6, 7.8] } }];`