### PR TITLE
Generate macOS (Darwin) arm64 release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -43,3 +43,4 @@ do
   build "${os}" amd64
 done
 build linux arm64
+build darwin arm64


### PR DESCRIPTION
I am able to generate a macOS arm64 (aarch64) protolock binary with this simple addition. This is required by [proto-backwards-compat-maven-plugin|https://github.com/salesforce/proto-backwards-compat-maven-plugin] to work natively with ARM Macs.

Tested with macOS 11.2.1 (20D74), go1.16rc1 darwin/arm64 (installed via Homebrew).

Please kindly review. :D
