### PR TITLE
Update parse to handle enum options

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -71,6 +71,7 @@ type Enum struct {
 	ReservedIDs   []int       `json:"reserved_ids,omitempty"`
 	ReservedNames []string    `json:"reserved_names,omitempty"`
 	AllowAlias    bool        `json:"allow_alias,omitempty"`
+	Options       []Option    `json:"options,omitempty"`
 }
 
 type Map struct {
@@ -204,6 +205,13 @@ func parseEnum(e *proto.Enum) Enum {
 				}
 			}
 			enum.EnumFields = append(enum.EnumFields, field)
+		}
+
+		if o, ok := v.(*proto.Option); ok {
+			enum.Options = append(enum.Options, Option{
+				Name:  o.Name,
+				Value: o.Constant.Source,
+			})
 		}
 
 		if r, ok := v.(*proto.Reserved); ok {

--- a/proto.lock
+++ b/proto.lock
@@ -107,6 +107,12 @@
             ],
             "reserved_ids": [
               2
+            ],
+            "options": [
+              {
+                "name": "allow_alias",
+                "value": "true"
+              }
             ]
           }
         ],
@@ -330,6 +336,12 @@
             ],
             "reserved_ids": [
               2
+            ],
+            "options": [
+              {
+                "name": "allow_alias",
+                "value": "true"
+              }
             ]
           },
           {


### PR DESCRIPTION
Hey @nilslice, finally got around to working through this. This fixes #135 

One thing to note- it seems like the AllowAlias field in the Enum object doesn't actually get populated. I left it in there in case any plugin relies on it, but the Options field now encapsulates that logic.