### PR TITLE
Support required and optional labels

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -83,6 +83,8 @@ type Field struct {
 	Name       string   `json:"name,omitempty"`
 	Type       string   `json:"type,omitempty"`
 	IsRepeated bool     `json:"is_repeated,omitempty"`
+	IsOptional bool     `json:"optional,omitempty"`
+	IsRequired bool     `json:"required,omitempty"`
 	Options    []Option `json:"options,omitempty"`
 }
 
@@ -291,6 +293,8 @@ func parseMessage(m *proto.Message) Message {
 				Name:       f.Name,
 				Type:       f.Type,
 				IsRepeated: f.Repeated,
+				IsOptional: f.Optional,
+				IsRequired: f.Required,
 				Options:    parseOptions(f.Options),
 			})
 		}

--- a/parse_test.go
+++ b/parse_test.go
@@ -133,6 +133,17 @@ message Channel {
 }
 `
 
+const protoWithRequiredAndOptionalFields = `
+syntax = "proto2";
+
+package test;
+
+message Channel {
+  required int64 id = 1;
+  optional string name = 2;
+}
+`
+
 const protoWithRpcOptions = `
 syntax = "proto3";
 
@@ -173,6 +184,16 @@ func TestParseSingleQuoteReservedNames(t *testing.T) {
 		[]string{"thing", "another", "more", "mixed"},
 		entry.Messages[0].ReservedNames,
 	)
+}
+
+func TestParseRequiredAndOptionalFields(t *testing.T) {
+	r := strings.NewReader(protoWithRequiredAndOptionalFields)
+
+	entry, err := Parse("test:protoWithRequiredAndOptionalFields", r)
+	assert.NoError(t, err)
+
+	assert.True(t, entry.Messages[0].Fields[0].IsRequired)
+	assert.True(t, entry.Messages[0].Fields[1].IsOptional)
 }
 
 func TestParseIncludingImports(t *testing.T) {


### PR DESCRIPTION
Hi - is there any chance we could get support for `required`/`optional` field labels? This would allow the implementation of plugins that make use of `required`/`optional`. Specifically we are looking to implement a check that a `required` field is not changed to `optional`.