### PR TITLE
Add support for checking whether an existing field has moved into or out of a oneof

### DIFF
--- a/cmd/protolock/main.go
+++ b/cmd/protolock/main.go
@@ -51,7 +51,7 @@ var (
 func main() {
 	// exit if no command (i.e. help, -h, --help, init, status, or commit)
 	if len(os.Args) < 2 {
-		fmt.Println(info + usage)
+		fmt.Print(info + usage)
 		os.Exit(0)
 	}
 
@@ -75,7 +75,7 @@ func main() {
 	// switch through known commands
 	switch os.Args[1] {
 	case "-h", "--help", "help":
-		fmt.Println(usage)
+		fmt.Print(usage)
 
 	case "init":
 		r, err := protolock.Init(*cfg)

--- a/parse.go
+++ b/parse.go
@@ -80,13 +80,14 @@ type Map struct {
 }
 
 type Field struct {
-	ID         int      `json:"id,omitempty"`
-	Name       string   `json:"name,omitempty"`
-	Type       string   `json:"type,omitempty"`
-	IsRepeated bool     `json:"is_repeated,omitempty"`
-	IsOptional bool     `json:"optional,omitempty"`
-	IsRequired bool     `json:"required,omitempty"`
-	Options    []Option `json:"options,omitempty"`
+	ID          int      `json:"id,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Type        string   `json:"type,omitempty"`
+	IsRepeated  bool     `json:"is_repeated,omitempty"`
+	IsOptional  bool     `json:"optional,omitempty"`
+	IsRequired  bool     `json:"required,omitempty"`
+	Options     []Option `json:"options,omitempty"`
+	OneofParent string   `json:"oneof_parent,omitempty"`
 }
 
 type Service struct {
@@ -326,11 +327,12 @@ func parseMessage(m *proto.Message) Message {
 			for _, el := range oo.Elements {
 				if f, ok := el.(*proto.OneOfField); ok {
 					fields = append(fields, Field{
-						ID:         f.Sequence,
-						Name:       f.Name,
-						Type:       f.Type,
-						IsRepeated: false,
-						Options:    parseOptions(f.Options),
+						ID:          f.Sequence,
+						Name:        f.Name,
+						Type:        f.Type,
+						IsRepeated:  false,
+						Options:     parseOptions(f.Options),
+						OneofParent: oo.Name,
 					})
 				}
 			}

--- a/parse_test.go
+++ b/parse_test.go
@@ -196,6 +196,22 @@ message TestNestedEnumOption {
 }
 `
 
+const protoWithOneof = `
+syntax = "proto3";
+
+import "testdata/test.proto";
+
+package test;
+
+message Channel {
+  oneof test_oneof {
+  	int64 id = 1;
+  }
+  string name = 2;
+  string description = 3;
+}
+`
+
 var gpfPath = filepath.Join("testdata", "getProtoFiles")
 
 func TestParseSingleQuoteReservedNames(t *testing.T) {
@@ -413,6 +429,19 @@ func TestParseWithoutEntryOptionsWithRPCOptions(t *testing.T) {
 
 	assert.Len(t, entry.Options, 0)
 	assert.Len(t, entry.Services[0].RPCs[0].Options, 2)
+}
+
+func TestParseWithOneof(t *testing.T) {
+	r := strings.NewReader(protoWithOneof)
+
+	entry, err := Parse("test:protoWithOneof", r)
+	assert.NoError(t, err)
+
+	assert.Len(t, entry.Messages, 1)
+	assert.Len(t, entry.Messages[0].Fields, 3)
+	assert.Equal(t, "test_oneof", entry.Messages[0].Fields[0].OneofParent)
+	assert.Equal(t, "", entry.Messages[0].Fields[1].OneofParent)
+	assert.Equal(t, "", entry.Messages[0].Fields[2].OneofParent)
 }
 
 func TestGetProtoFilesFiltersDirectories(t *testing.T) {

--- a/proto.lock
+++ b/proto.lock
@@ -503,12 +503,14 @@
               {
                 "id": 4,
                 "name": "name",
-                "type": "string"
+                "type": "string",
+                "oneof_parent": "test_oneof"
               },
               {
                 "id": 9,
                 "name": "is_active",
-                "type": "bool"
+                "type": "bool",
+                "oneof_parent": "test_oneof"
               }
             ]
           },

--- a/rules.go
+++ b/rules.go
@@ -41,6 +41,10 @@ var (
 			Name: "NoChangingRPCSignature",
 			Func: NoChangingRPCSignature,
 		},
+		{
+			Name: "NoMovingExistingFieldsIntoOrOutOfOneof",
+			Func: NoMovingExistingFieldsIntoOrOutOfOneof,
+		},
 	}
 
 	strict = true


### PR DESCRIPTION
Resolves https://github.com/nilslice/protolock/issues/133 by adding a `OneofParent` field to a `Field` type.

Adds a rule checking whether a field has been moved into or out of a `oneof`, which is a backwards-incompatible change for Go protobuf stubs per https://google.aip.dev/180#moving-into-oneofs.

In addition to the passing unit tests, I've also tested this locally via our custom tooling & protolock plugins and verified it behaves as expected.